### PR TITLE
Fix tables.records generator when min_records >= 2 and table has no unique columns

### DIFF
--- a/hypothesis_sqlalchemy/records.py
+++ b/hypothesis_sqlalchemy/records.py
@@ -57,11 +57,9 @@ def lists_factory(columns: List[Column],
                       for index, column in enumerate(columns)
                       if is_column_unique(column)]
 
-    def to_unique_fields(row: Tuple[Any, ...]) -> Tuple[Any, ...]:
-        return tuple(row[index] for index in unique_indices)
-
     if unique_indices:
-        unique_by = to_unique_fields
+        def unique_by(row: Tuple[Any, ...]) -> Tuple[Any, ...]:
+            return tuple(row[index] for index in unique_indices)
     else:
         unique_by = None
 

--- a/hypothesis_sqlalchemy/records.py
+++ b/hypothesis_sqlalchemy/records.py
@@ -60,10 +60,15 @@ def lists_factory(columns: List[Column],
     def to_unique_fields(row: Tuple[Any, ...]) -> Tuple[Any, ...]:
         return tuple(row[index] for index in unique_indices)
 
+    if unique_indices:
+        unique_by = to_unique_fields
+    else:
+        unique_by = None
+
     return strategies.lists(values_tuples,
                             min_size=min_size,
                             max_size=max_size,
-                            unique_by=to_unique_fields)
+                            unique_by=unique_by)
 
 
 booleans_factory = strategies.booleans

--- a/tests/strategies/tables.py
+++ b/tests/strategies/tables.py
@@ -1,7 +1,18 @@
+from operator import attrgetter
+
 from hypothesis import strategies
 from sqlalchemy import MetaData
 
-from hypothesis_sqlalchemy import tables
+from hypothesis_sqlalchemy import (columns,
+                                   tables)
 
 metadata = MetaData()
-tables = tables.factory(metadatas=strategies.just(metadata))
+non_unique_columns = columns.non_primary_keys_factory(
+        are_unique=strategies.just(False))
+tables_without_unique_columns = tables.factory(
+        metadatas=strategies.just(metadata),
+        columns_lists=strategies.lists(non_unique_columns,
+                                       unique_by=attrgetter('name')))
+tables_with_unique_columns = tables.factory(
+        metadatas=strategies.just(metadata))
+tables = tables_without_unique_columns | tables_with_unique_columns

--- a/tests/test_tables/test_records.py
+++ b/tests/test_tables/test_records.py
@@ -19,7 +19,8 @@ def test_table_records_factory(table: Table) -> None:
 
 
 def test_table_records_lists_factory(table: Table) -> None:
-    table_records_lists = records.lists_factory(table, min_size=2)
+    table_records_lists = records.lists_factory(table,
+                                                min_size=2)
     table_records = example(table_records_lists)
 
     assert isinstance(table_records_lists, SearchStrategy)

--- a/tests/test_tables/test_records.py
+++ b/tests/test_tables/test_records.py
@@ -1,7 +1,10 @@
 from functools import partial
 
 from hypothesis.searchstrategy import SearchStrategy
-from sqlalchemy.schema import Table
+from sqlalchemy.schema import (Column,
+                               MetaData,
+                               Table)
+from sqlalchemy.sql.sqltypes import Integer
 
 from hypothesis_sqlalchemy.tables import records
 from tests.utils import (example,
@@ -20,6 +23,19 @@ def test_table_records_factory(table: Table) -> None:
 
 def test_table_records_lists_factory(table: Table) -> None:
     table_records_lists = records.lists_factory(table)
+    _do_test_table_records_lists_factory(table, table_records_lists)
+
+
+def test_table_records_lists_factory_for_table_without_primary_key() -> None:
+    metadata = MetaData()
+    table = Table('numbers', metadata, Column('number', Integer))
+    # min_size = 2 is added as a regression test for a corner-case where the
+    # absence of a primary key prevented multiple records from being generated:
+    table_records_lists = records.lists_factory(table, min_size=2)
+    _do_test_table_records_lists_factory(table, table_records_lists)
+
+
+def _do_test_table_records_lists_factory(table: Table, table_records_lists: SearchStrategy) -> None:
     table_records = example(table_records_lists)
 
     assert isinstance(table_records_lists, SearchStrategy)

--- a/tests/test_tables/test_records.py
+++ b/tests/test_tables/test_records.py
@@ -1,10 +1,7 @@
 from functools import partial
 
 from hypothesis.searchstrategy import SearchStrategy
-from sqlalchemy.schema import (Column,
-                               MetaData,
-                               Table)
-from sqlalchemy.sql.sqltypes import Integer
+from sqlalchemy.schema import Table
 
 from hypothesis_sqlalchemy.tables import records
 from tests.utils import (example,
@@ -22,20 +19,7 @@ def test_table_records_factory(table: Table) -> None:
 
 
 def test_table_records_lists_factory(table: Table) -> None:
-    table_records_lists = records.lists_factory(table)
-    _do_test_table_records_lists_factory(table, table_records_lists)
-
-
-def test_table_records_lists_factory_for_table_without_primary_key() -> None:
-    metadata = MetaData()
-    table = Table('numbers', metadata, Column('number', Integer))
-    # min_size = 2 is added as a regression test for a corner-case where the
-    # absence of a primary key prevented multiple records from being generated:
     table_records_lists = records.lists_factory(table, min_size=2)
-    _do_test_table_records_lists_factory(table, table_records_lists)
-
-
-def _do_test_table_records_lists_factory(table: Table, table_records_lists: SearchStrategy) -> None:
     table_records = example(table_records_lists)
 
     assert isinstance(table_records_lists, SearchStrategy)


### PR DESCRIPTION
This PR fixes a corner case bug in the `tables.records` generator: if `min_records >= 2` and the table schema has no unique columns then Hypothesis would fail to generate examples.

The problem is the `unique_by` function passed to `strategies.lists`: if a table has no unique columns then `to_unique_fields()` will return an empty tuple for every record, causing all records to have the same uniqueness key. Instead, I think we should pass `unique_by=None` when there are no unique columns.

Here, I added a regression test and implemented that fix.

(Thanks for the cool library! I'm experimenting with using Hypothesis for testing SQL database engines and your code has been useful for handling the data generation pieces.)