### PR TITLE
Updated to work with latest hypothesis >= 4.53.2

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,7 +1,7 @@
 jobs:
   - job: 'Windows'
     pool:
-      vmImage: 'vs2017-win2016'
+      vmImage: 'windows-latest'
     strategy:
       matrix:
         Python35_x86:
@@ -49,7 +49,7 @@ jobs:
 
   - job: 'MacOS'
     pool:
-      vmImage: 'macOS-10.13'
+      vmImage: 'macOS-latest'
     strategy:
       matrix:
         Python35:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-sudo: false
-distro: trusty
+distro: xenial
 
 language: python
 
@@ -10,8 +9,6 @@ matrix:
     - python: 3.5
     - python: 3.6
     - python: 3.7
-      dist: xenial
-      sudo: true
 
 install:
   - python -m pip install codecov

--- a/hypothesis_sqlalchemy/hints.py
+++ b/hypothesis_sqlalchemy/hints.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 from typing import (Tuple,
                     Union)
 
-from hypothesis.searchstrategy import SearchStrategy
+from hypothesis.strategies import SearchStrategy
 
 ColumnValueType = Union[int, bool,
                         float, Decimal, str, None,

--- a/hypothesis_sqlalchemy/tabular/records.py
+++ b/hypothesis_sqlalchemy/tabular/records.py
@@ -1,6 +1,5 @@
 from typing import Optional
 
-from hypothesis.searchstrategy.collections import TupleStrategy
 from sqlalchemy import Table
 
 from hypothesis_sqlalchemy import columnar
@@ -8,7 +7,7 @@ from hypothesis_sqlalchemy.hints import Strategy
 
 
 def factory(table: Table,
-            **fixed_columns_values: Strategy) -> TupleStrategy:
+            **fixed_columns_values: Strategy) -> Strategy:
     return columnar.records.factory(table.columns,
                                     **fixed_columns_values)
 
@@ -17,7 +16,7 @@ def lists_factory(table: Table,
                   *,
                   min_size: int = 0,
                   max_size: Optional[int] = None,
-                  **fixed_columns_values: Strategy) -> TupleStrategy:
+                  **fixed_columns_values: Strategy) -> Strategy:
     return columnar.records.lists_factory(table.columns,
                                           table.constraints,
                                           min_size=min_size,


### PR DESCRIPTION
Hi,

When using latest versions of hypothesis, the import fails with:

> \>\>\> from hypothesis_sqlalchemy import tabular
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/tmp/hypothesis_sqlalchemy/hypothesis_sqlalchemy/tabular/\_\_init\_\_.py", line 1, in <module>
    from . import records
  File "/tmp/hypothesis_sqlalchemy/hypothesis_sqlalchemy/tabular/records.py", line 3, in <module>
    from hypothesis.searchstrategy.collections import TupleStrategy
ModuleNotFoundError: No module named 'hypothesis.searchstrategy'
